### PR TITLE
fixes naming error for exact drift beam element

### DIFF
--- a/pysixtrack/loader_mad.py
+++ b/pysixtrack/loader_mad.py
@@ -8,7 +8,7 @@ def _from_madx_sequence(
 ):
 
     if exact_drift:
-        myDrift = classes.ExactDrift
+        myDrift = classes.DriftExact
     else:
         myDrift = classes.Drift
     seq = sequence


### PR DESCRIPTION
(i.e. s/ExactDrift/DriftExact/g)

