### PR TITLE
cavity fix for non-unity charged ions (overall charge missing)

### DIFF
--- a/pysixtrack/elements.py
+++ b/pysixtrack/elements.py
@@ -150,7 +150,7 @@ class Cavity(Element):
         k = 2 * pi * self.frequency / p.clight
         tau = p.zeta / p.rvv / p.beta0
         phase = self.lag * pi / 180 - k * tau
-        p.add_to_energy(p.chi * self.voltage * sin(phase))
+        p.add_to_energy(p.qratio * p.q0 * self.voltage * sin(phase))
 
 
 class XYShift(Element):


### PR DESCRIPTION
In analogy to [SixTrackLib PR#97](https://github.com/SixTrack/sixtracklib/pull/97), use voltage in Cavity as integrated E field strength (externally applied physical voltage in the engineering sense) instead of the particle dependent energy increase.

(This PR originally addressed `rdemaria/pysixtrack`, https://github.com/rdemaria/pysixtrack/pull/26)