### PR TITLE
Fix state turn elemid init

### DIFF
--- a/pysixtrack/particles.py
+++ b/pysixtrack/particles.py
@@ -246,19 +246,21 @@ class Particles(object):
         self.__init__chi(chi, mratio, qratio)
         self._update_coordinates = True
         length = self._check_array_length()
+
         if partid is None:
-            if length is not None:
-                partid = np.arange(length)
+            partid = np.arange(length) if length is not None else 0
         self.partid = partid
 
         if turn is None:
-            if length is not None:
-                turn = np.zeros(length)
+            turn = np.zeros(length) if length is not None else 0
         self.turn = turn
 
+        if elemid is None:
+            elemid = np.zeros(length) if length is not None else 0
+        self.elemid = elemid
+
         if state is None:
-            if length is not None:
-                state = np.zeros(length)
+            state = np.ones(length) if length is not None else 1
         self.state = state
 
         self.lost_particles = []

--- a/pysixtrack/particles.py
+++ b/pysixtrack/particles.py
@@ -476,9 +476,7 @@ class Particles(object):
 
             if np.any(~mask_valid):
                 if keep_memory:
-                    to_trash = (
-                        self.copy()
-                    )  # Not exactly efficient (but robust)
+                    to_trash = self.copy()  # Not exactly efficient (but robust)
                     for ff in self._dict_vars:
                         if hasattr(getattr(self, ff), "__iter__"):
                             setattr(

--- a/pysixtrack/particles.py
+++ b/pysixtrack/particles.py
@@ -224,7 +224,7 @@ class Particles(object):
         qratio=None,
         partid=None,
         turn=None,
-        state=None,  # ==1 particle lost
+        state=None,  # == 0 particle lost, == 1 particle active
         elemid=None,
         mathlib=MathlibDefault,
         **args,


### PR DESCRIPTION
- Explicitly initialises the elemid, turn, partid and state variables if no values are provided. 
- Attempts to clarify the inconsistency reported in #46
- Attempts to initialise the particle with sane defaults if no values are provided (cf. #14) 
- Consequently, prevents issues with SixTrackLib's from_pysixtrack() method if the pysixtrack Particles instance does not have proper values for these attributes