### PR TITLE
fix setters of p0c and delta to update _rvv and zeta

### DIFF
--- a/pysixtrack/particles.py
+++ b/pysixtrack/particles.py
@@ -310,8 +310,14 @@ class Particles(object):
         self._delta = delta
         deltabeta0 = delta * self.beta0
         ptaubeta0 = sqrt(deltabeta0 ** 2 + 2 * deltabeta0 * self.beta0 + 1) - 1
+        if hasattr(self,'_rvv'):
+            oldrvv = self._rvv
+        else:
+            oldrvv = None
         self._rvv = (1 + self.delta) / (1 + ptaubeta0)
         self._rpp = 1 / (1 + self.delta)
+        if oldrvv:
+            self.zeta *= self._rvv / oldrvv
 
     psigma = property(lambda self: self.ptau / self.beta0)
 
@@ -424,12 +430,15 @@ class Particles(object):
         if self._update_coordinates:
             mratio = self.mass / self.mass0
             norm = mratio * self.p0c
+            oldrvv = self._rvv
             self._mratio = mratio
             self._chi = self._qratio / mratio
             self._ptau = energy / norm - 1
             self._delta = pc / norm - 1
+            self._rvv = self.beta / self.beta0
             self.px = Px / norm
             self.py = Py / norm
+            self.zeta *= self._rvv / oldrvv
 
     def __repr__(self):
         out = f"""\


### PR DESCRIPTION
Fix for issue #55 

However, I am not 100% pleased with the current status: 
- For one, I am not sure if there are other parameters to be updated as well (_rpp?). 
- The next problem is that _update_particles_from_absolute() is now updating zeta, but relatively, not from absolute like the function name suggests... we might want to create a differently named function for that?
- Lastly the delta.setter now has to check whether the attribute _rvv already exists (as it is also used during initialization) in order to update zeta. Again we might want to change the program flow a bit more here.