### PR TITLE
loader of MAD-X errors

### DIFF
--- a/pysixtrack/line.py
+++ b/pysixtrack/line.py
@@ -498,11 +498,12 @@ class Line(Element):
 
             if element.field_errors:
                 # add multipole error
-                knl = element.field_errors.dkn
-                ksl = element.field_errors.dks
-                knl = knl[:np.amax(np.where(knl)) + 1]  # delete trailing zeros
-                ksl = ksl[:np.amax(np.where(ksl)) + 1]  # to keep order low
-                if any(knl) or any(ksl):
+                if any(element.field_errors.dkn) or \
+                            any(element.field_errors.dks):
+                    knl = element.field_errors.dkn
+                    ksl = element.field_errors.dks
+                    knl = knl[:np.amax(np.where(knl)) + 1]  # delete trailing zeros
+                    ksl = ksl[:np.amax(np.where(ksl)) + 1]  # to keep order low
                     self._add_multipole_error_to(element_name, knl, ksl)
 
         return elements_not_found

--- a/pysixtrack/line.py
+++ b/pysixtrack/line.py
@@ -327,8 +327,8 @@ class Line(Element):
         ignored_madtypes=[],
         exact_drift=False,
         drift_threshold=1e-6,
-        apply_madx_errors=False,
         install_apertures=False,
+        apply_madx_errors=False,
     ):
 
         line = cls(elements=[], element_names=[])

--- a/pysixtrack/line.py
+++ b/pysixtrack/line.py
@@ -487,9 +487,10 @@ class Line(Element):
                     self._add_aperture_offset_error_to(element_name, arex, arey)
 
                 # check for errors which cannot be treated yet:
-                for error_type in ['ds', 'dphi', 'dtheta', 'mrex', 'mrey',
-                                   'mredx', 'mredy', 'mscalx', 'mscaly']:
-                    if getattr(element.align_errors, error_type):
+                for error_type in dir(element.align_errors):
+                    if not error_type[0] == '_' and \
+                            error_type not in ['dx', 'dy', 'dpsi', 'arex',
+                                               'arey', 'count', 'index']:
                         print(
                             f'Warning: MAD-X error type "{error_type}"'
                             " not implemented yet."

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -34,24 +34,24 @@ def test_line():
     n_elements += 1
     assert len(line) == n_elements
 
-    line.add_offset_error_to(multipole_name, dx=0, dy=0)
+    line._add_offset_error_to(multipole_name, dx=0, dy=0)
     n_elements += 2
     assert len(line) == n_elements
 
-    line.add_offset_error_to(multipole_name, dx=0.2, dy=-0.003)
+    line._add_offset_error_to(multipole_name, dx=0.2, dy=-0.003)
     n_elements += 2
     assert len(line) == n_elements
 
-    line.add_tilt_error_to(multipole_name, angle=0)
+    line._add_tilt_error_to(multipole_name, angle=0)
     n_elements += 2
     assert len(line) == n_elements
 
-    line.add_tilt_error_to(multipole_name, angle=0.1)
+    line._add_tilt_error_to(multipole_name, angle=0.1)
     n_elements += 2
     assert len(line) == n_elements
 
-    line.add_multipole_error_to(multipole_name, knl=[0, 0.1], ksl=[-0.03, 0.01])
-    # line.add_multipole_error_to(drift_exact,knl=[0,0.1],ksl=[-0.03,0.01])
+    line._add_multipole_error_to(multipole_name, knl=[0, 0.1], ksl=[-0.03, 0.01])
+    # line._add_multipole_error_to(drift_exact,knl=[0,0.1],ksl=[-0.03,0.01])
 
     line_dict = line.to_dict()
     line = pysixtrack.Line.from_dict(line_dict)

--- a/tests/test_madx_import.py
+++ b/tests/test_madx_import.py
@@ -403,3 +403,42 @@ def test_error_functionality():
     assert not ret
     assert np.all([T1_checked, T1_aper_checked,
                    T2_checked, T3_checked, T3_aper_checked])
+
+
+def test_zero_errors():
+    # check that zero-errors are loaded without erro
+    cpymad_spec = util.find_spec("cpymad")
+    if cpymad_spec is None:
+        print("cpymad is not available - abort test")
+        sys.exit(0)
+
+    from cpymad.madx import Madx
+
+    madx = Madx()
+    madx.input('''
+        qd: multipole, knl={0,-0.3};
+        qf: multipole, knl={0, 0.3};
+        testseq: sequence, l = 1;
+            qd, at = 0.3;
+            qf, at = 0.6;
+        endsequence;
+    ''')
+    madx.select(flag='error', pattern='qf')
+    madx.command.efcomp(
+        dkn=[0, 0, 0, 0, 0.0, 0.0, 0.0],
+        dks=[0.0, 0.0, 0, 0]
+    )
+    madx.command.ealign(
+        dx=0.0,
+        dy=0.0,
+        ds=0.0,
+        DPHI=0.0,
+        DTHETA=0.0,
+        DPSI=0.0,
+        MREX=0.0,
+        MREY=0.0,
+        MSCALX=0.0,
+        MSCALY=0.0,
+        AREX=0.0,
+        AREY=0.0
+    )

--- a/tests/test_madx_import.py
+++ b/tests/test_madx_import.py
@@ -255,7 +255,7 @@ def test_neutral_errors():
         USE, SEQUENCE=testseq;
 
 
-        Select, flag=makethin, pattern="MQ1", slice=2;
+        Select, flag=makethin, pattern="T1", slice=2;
         makethin, sequence=testseq;
 
         use, sequence=testseq;

--- a/tests/test_madx_import.py
+++ b/tests/test_madx_import.py
@@ -153,18 +153,13 @@ def test_error_import():
         select, flag = error, clear;
         select, flag = error, pattern = "MQ3";
         ealign, dx = 0.00, dy = 0.00, arex = 0.00, arey = 0.00, dpsi = 0.00;
-        efcomp, DKN = {0.0, 0.0, 0.001, 0.002}, DKS = {0.0, 0.0, 0.003, 0.004};
+        efcomp, DKN = {0.0, 0.0, 0.001, 0.002}, DKS = {0.0, 0.0, 0.003, 0.004, 0.005};
         select, flag = error, full;
     ''')
     seq = madx.sequence.testseq
-    # store already applied errors:
-    madx.command.esave(file='lattice_errors.err')
-    madx.command.readtable(file='lattice_errors.err', table="errors")
-    os.remove('lattice_errors.err')
-    errors = madx.table.errors
 
     pysixtrack_line = pysixtrack.Line.from_madx_sequence(seq, install_apertures=True)
-    pysixtrack_line.apply_madx_errors(errors)
+    pysixtrack_line.apply_madx_errors(seq)
     madx.input('stop;')
 
     expected_element_num = (
@@ -224,6 +219,7 @@ def test_error_import():
     assert abs(MQ3.knl[3] - 0.002) < 1e-14
     assert abs(MQ3.ksl[2] - 0.003) < 1e-14
     assert abs(MQ3.ksl[3] - 0.004) < 1e-14
+    assert abs(MQ3.ksl[4] - 0.005) < 1e-14
 
 
 def test_neutral_errors():
@@ -274,14 +270,9 @@ def test_neutral_errors():
         select, flag = error, full;
     ''')
     seq = madx.sequence.testseq
-    # store already applied errors:
-    madx.command.esave(file='lattice_errors.err')
-    madx.command.readtable(file='lattice_errors.err', table="errors")
-    os.remove('lattice_errors.err')
-    errors = madx.table.errors
 
     pysixtrack_line = pysixtrack.Line.from_madx_sequence(seq, install_apertures=True)
-    pysixtrack_line.apply_madx_errors(errors)
+    pysixtrack_line.apply_madx_errors(seq)
     madx.input('stop;')
 
     initial_x = 0.025

--- a/tests/test_madx_import.py
+++ b/tests/test_madx_import.py
@@ -158,8 +158,11 @@ def test_error_import():
     ''')
     seq = madx.sequence.testseq
 
-    pysixtrack_line = pysixtrack.Line.from_madx_sequence(seq, install_apertures=True)
-    pysixtrack_line.apply_madx_errors(seq)
+    pysixtrack_line = pysixtrack.Line.from_madx_sequence(
+            seq,
+            install_apertures=True,
+            apply_madx_errors=True,
+    )
     madx.input('stop;')
 
     expected_element_num = (
@@ -271,8 +274,11 @@ def test_neutral_errors():
     ''')
     seq = madx.sequence.testseq
 
-    pysixtrack_line = pysixtrack.Line.from_madx_sequence(seq, install_apertures=True)
-    pysixtrack_line.apply_madx_errors(seq)
+    pysixtrack_line = pysixtrack.Line.from_madx_sequence(
+            seq,
+            install_apertures=True,
+            apply_madx_errors=True,
+    )
     madx.input('stop;')
 
     initial_x = 0.025
@@ -327,8 +333,11 @@ def test_error_functionality():
     ''')
     seq = madx.sequence.testseq
 
-    pysixtrack_line = pysixtrack.Line.from_madx_sequence(seq, install_apertures=True)
-    pysixtrack_line.apply_madx_errors(seq)
+    pysixtrack_line = pysixtrack.Line.from_madx_sequence(
+            seq,
+            install_apertures=True,
+            apply_madx_errors=True,
+    )
     madx.input('stop;')
 
     x_init = 0.1*np.random.rand(10)


### PR DESCRIPTION
This PR changes the loader of MAD-X errors so it uses a new feature of cpymad that allows us to access element errors directly instead of saving them to a file in cpymad and then loading the file in pysixtrack.

Furthermore the function line.apply_madx_errors was made private and is now an option of line.from_madx_sequence. This way we fix #42 without taking the possibility to still manually load errors. Similarly the apply_xyz_error_to function were made private to "fix" #53 without needing any housekeeping of the misalignments.